### PR TITLE
Fix floating footer bar

### DIFF
--- a/components/CodeEditor.js
+++ b/components/CodeEditor.js
@@ -1,10 +1,10 @@
-import './CodeEditor.css';
 import state from './state.js';
 
 import CodeMirror from 'codemirror';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/mode/sql/sql.js';
 import 'codemirror/mode/r/r.js';
+import './CodeEditor.css';
 
 /**
  * CodeEditor component wraps a CodeMirror v5 instance and syncs its content with central state

--- a/components/db.js
+++ b/components/db.js
@@ -38,7 +38,7 @@ export default class DB {
     await conn.send("ATTACH 'cloudspecs.duckdb' AS specs;");
     await conn.send("USE specs;");
 
-    return new DB(db, conn)
+    return new DB(db, conn);
   }
 
   async query(q) {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8" />
-  <title>Cloudspecs</title>
+  <title>cloudspecs</title>
   <link id="favicon" rel="icon" type="image/svg+xml" href="static/logo/cloudspecs.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="/style.css">


### PR DESCRIPTION
Import order of codemirror styles seems to have messed up editor size and pushed footer out of visible window size.
Importing our custom editor css last should fix the issue.